### PR TITLE
use https instead of ssh for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "lib/xptools"]
 	path = lib/xptools
-	url = git@github.com:azonenberg/xptools.git
+	url = https://github.com/azonenberg/xptools.git
 [submodule "lib/log"]
 	path = lib/log
-	url = git@github.com:azonenberg/logtools.git
+	url = https://github.com/azonenberg/logtools.git
 [submodule "lib/scpi-server-tools"]
 	path = lib/scpi-server-tools
-	url = git@github.com:glscopeclient/scpi-server-tools.git
+	url = https://github.com/glscopeclient/scpi-server-tools.git


### PR DESCRIPTION
This allows build systems that don't have access to GH SSH keys to still clone the repo's submodules. :)